### PR TITLE
Don't pan camera when path of Sun fits in FoV

### DIFF
--- a/src/SeasonsStory.vue
+++ b/src/SeasonsStory.vue
@@ -1108,10 +1108,10 @@ function updatePathInFoV() {
   const endPos = getSunPositionAtTime(new Date(endTime.value));
   const context = WWTControl.singleton.renderContext;
   let azWidth = Math.abs(endPos.azRad - startPos.azRad) * R2D;
-  const widthToFit = 0.075 * 0.9 * context.width + 12;
+  const widthToFit = 47.8 * Math.log(0.9 * context.width) - 245;
   const peakNorth = Math.min(Math.abs(middayAltAz.value.azRad), Math.abs(middayAltAz.value.azRad - 2 * Math.PI)) < Math.abs(middayAltAz.value.azRad - Math.PI);
   if (peakNorth) {
-    azWidth= 360 - azWidth;
+    azWidth = 360 - azWidth;
   }
   pathInFoV.value = (azWidth < widthToFit);
 }


### PR DESCRIPTION
This PR resolves #52. The idea here is to split the "camera tracking" logic into two pieces - whether or not the user has selected the "Track Sun" checkbox, and whether or not the path lies in the FoV. `forceCamera` is now a computed that is true when both the checkbox is checked and the path does NOT lie completely in the FoV.

Because only the vertical extent of the FoV is preserved on a resize, we need to redetermine whether the path lies in the FoV when the WWT canvas is resized.