### PR TITLE
Add analemma layer

### DIFF
--- a/src/SeasonsStory.vue
+++ b/src/SeasonsStory.vue
@@ -810,7 +810,8 @@ import { v4 } from "uuid";
 
 import { AstroTime, Seasons } from "astronomy-engine";
 
-import { Color, Grids, Planets, Settings, WWTControl } from "@wwtelescope/engine";
+import { Color, Grids, Planets, Settings, SpreadSheetLayer, WWTControl } from "@wwtelescope/engine";
+import { MarkerScales } from "@wwtelescope/engine-types";
 import { GotoRADecZoomParams, engineStore } from "@wwtelescope/engine-pinia";
 import {
   BackgroundImageset,
@@ -1453,6 +1454,8 @@ const selectedLocaledTimeDateString = computed(() => {
 
 const MAX_ZOOM = 500;
 
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
 function aspectRatioSetup() {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error WWTControl does have a canvas element (that's not TS-exposed)
@@ -1520,6 +1523,10 @@ onMounted(() => {
     layersLoaded.value = true;
 
     questionDisplaySetup();
+
+    const layer = await createAnalemmaLayer({ year: 2026, dayFraction: 0.35, daysBetween: 5 });
+    console.log(layer);
+
   });
 
   createUserEntry();
@@ -1675,6 +1682,49 @@ function resetView(zoomDeg?: number, withAzOffset=true) {
     zoomDeg: zoomDeg ?? MAX_ZOOM,
     instant: true,
   });
+}
+
+interface AnalemmaLayerOptions {
+  year: number;
+  dayFraction: number;
+  daysBetween: number;
+}
+
+function createAnalemmaLayer(options: AnalemmaLayerOptions): Promise<SpreadSheetLayer> {
+  const start = new Date(options.year, 0);
+  const delta = options.daysBetween * 24 * 60 * 60 * 1000;
+  const end = (new Date(options.year + 1, 0)).getTime();
+  let time = start.getTime() + options.dayFraction * MILLISECONDS_PER_DAY;
+
+  const points: string[] = [];
+  while (time < end) {
+    const date = new Date(time);
+    const sunPosition = getSunPositionAtTime(date);
+    const raDec = horizontalToEquatorial(
+      sunPosition.altRad,
+      sunPosition.azRad,
+      selectedLocation.value.latitudeDeg * D2R,
+      selectedLocation.value.longitudeDeg * D2R,
+      store.currentTime,
+    );
+    points.push(`${raDec.raRad * R2D}\t${raDec.decRad * R2D}`);
+    time += delta;
+  }
+
+  const dataCsv = `RA\tDec\r\n${points.join('\r\n')}`;
+  return store.createTableLayer({
+    name: "Analemma",
+    referenceFrame: "Sky",
+    dataCsv,
+  }).then(layer => {
+    layer.set_color(Color.fromArgb(255, 255, 255, 0));
+    layer.set_scaleFactor(50);
+    layer.set_lngColumn(0);
+    layer.set_latColumn(1);
+    layer.set_markerScale(MarkerScales.screen);
+    return layer;
+  });
+
 }
 
 function updateWWTLocation(location: LocationDeg) {

--- a/src/SeasonsStory.vue
+++ b/src/SeasonsStory.vue
@@ -1692,10 +1692,10 @@ interface AnalemmaLayerOptions {
 let analemmaAltAz: [number, number][] = [];
 
 function createAnalemmaAltAz(options: AnalemmaLayerOptions): [number, number][] {
-  const start = new Date(options.year, 0);
+  const start = new Date(Date.UTC(options.year, 0));
   const delta = options.daysBetween * MILLISECONDS_PER_DAY;
   const end = (new Date(options.year + 1, 0)).getTime();
-  let time = start.getTime() + options.dayFraction * MILLISECONDS_PER_DAY;
+  let time = start.getTime() + options.dayFraction * MILLISECONDS_PER_DAY - getTimezoneOffset(selectedTimezone.value, start);
   const points: [number, number][] = [];
   while (time < end) {
     const date = new Date(time);

--- a/src/SeasonsStory.vue
+++ b/src/SeasonsStory.vue
@@ -811,7 +811,7 @@ import { v4 } from "uuid";
 import { AstroTime, Seasons } from "astronomy-engine";
 
 import { Color, Grids, Planets, Settings, SpreadSheetLayer, WWTControl } from "@wwtelescope/engine";
-import { MarkerScales } from "@wwtelescope/engine-types";
+import { RAUnits, MarkerScales } from "@wwtelescope/engine-types";
 import { GotoRADecZoomParams, engineStore } from "@wwtelescope/engine-pinia";
 import {
   BackgroundImageset,
@@ -1689,31 +1689,42 @@ interface AnalemmaLayerOptions {
   daysBetween: number;
 }
 
-function createAnalemmaLayer(options: AnalemmaLayerOptions): Promise<SpreadSheetLayer> {
+let analemmaAltAz: [number, number][] = [];
+
+function createAnalemmaAltAz(options: AnalemmaLayerOptions): [number, number][] {
   const start = new Date(options.year, 0);
   const delta = options.daysBetween * MILLISECONDS_PER_DAY;
   const end = (new Date(options.year + 1, 0)).getTime();
   let time = start.getTime() + options.dayFraction * MILLISECONDS_PER_DAY;
-  console.log("Start time");
-  console.log(new Date(time));
-  console.log(selectedTimezoneOffset.value);
-
-  const points: string[] = [];
+  const points: [number, number][] = [];
   while (time < end) {
     const date = new Date(time);
     const sunPosition = getSunPositionAtTime(date);
-    const raDec = horizontalToEquatorial(
-      sunPosition.altRad,
-      sunPosition.azRad,
-      selectedLocation.value.latitudeDeg * D2R,
-      selectedLocation.value.longitudeDeg * D2R,
-      store.currentTime,
-    );
-    points.push(`${raDec.raRad * R2D}\t${raDec.decRad * R2D}`);
+    points.push([sunPosition.altRad, sunPosition.azRad]);
     time += delta;
   }
+  return points;
+}
 
-  const dataCsv = `RA\tDec\r\n${points.join('\r\n')}`;
+function createAnalemmaRADec(options: AnalemmaLayerOptions) {
+  if (analemmaAltAz.length === 0) {
+    analemmaAltAz = createAnalemmaAltAz(options);
+  }
+  return analemmaAltAz.map(([altRad, azRad]) => {
+    const raDec = horizontalToEquatorial(
+      altRad,
+      azRad,
+      selectedLocation.value.latitudeDeg * D2R,
+      selectedLocation.value.longitudeDeg * D2R,
+      currentTime.value,
+    );
+    return [raDec.raRad * R2D, raDec.decRad * R2D];
+  });
+}
+
+function createAnalemmaLayer(options: AnalemmaLayerOptions): Promise<SpreadSheetLayer> {
+  const points = createAnalemmaRADec(options);
+  const dataCsv = `RA\tDec\r\n${points.map(pt => pt.join('\t')).join('\r\n')}`;
   return store.createTableLayer({
     name: "Analemma",
     referenceFrame: "Sky",
@@ -1721,12 +1732,24 @@ function createAnalemmaLayer(options: AnalemmaLayerOptions): Promise<SpreadSheet
   }).then(layer => {
     layer.set_color(Color.fromArgb(255, 255, 255, 0));
     layer.set_scaleFactor(50);
+    layer.set_raUnits(RAUnits.degrees);
     layer.set_lngColumn(0);
     layer.set_latColumn(1);
     layer.set_markerScale(MarkerScales.screen);
     return layer;
   });
 
+}
+
+async function updateAnalemmaLayer(options: AnalemmaLayerOptions) {
+  if (!analemmaLayer) {
+    analemmaLayer = await createAnalemmaLayer(options);
+  } else {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const table = analemmaLayer._table$1; analemmaLayer.dirty = true;
+    table.rows = createAnalemmaRADec(options).map(pt => pt.map(t => String(t)));
+  }
 }
 
 function updateWWTLocation(location: LocationDeg) {
@@ -1777,6 +1800,15 @@ watch(selectedLocation, (location: LocationDeg, oldLocation: LocationDeg) => {
   updateWWTLocation(location);
   updateSliderBounds(location, oldLocation);
   resetView();
+
+  const options: AnalemmaLayerOptions = {
+    year: selectedCustomDate.value?.getFullYear() ?? 2026,
+    dayFraction: 0.5,
+    daysBetween: 5,
+  };
+
+  analemmaAltAz = createAnalemmaAltAz(options);
+  updateAnalemmaLayer(options);
 });
 
 watch(currentTime, (_time: Date) => {
@@ -1789,23 +1821,11 @@ watch(currentTime, (_time: Date) => {
     resetView(store.zoomDeg);
   }
   sunDistance.value = sunPlace.get_distance();
-});
-
-watch([selectedLocation, selectedCustomDate], async (values: [LocationDeg, Date | null]) => {
-  if (analemmaLayer) {
-    store.deleteLayer(analemmaLayer);
-  }
-
-  const date = values[1];
-  if (date != null) {
-    analemmaLayer = await createAnalemmaLayer({
-      year: date.getFullYear(),
-      dayFraction: 0.5,
-      daysBetween: 5,
-    });
-  } else {
-    analemmaLayer = null;
-  }
+  updateAnalemmaLayer({
+    year: selectedCustomDate.value?.getYear() ?? 2026,
+    dayFraction: 0.5,
+    daysBetween: 5,
+  });
 });
 
 watch(forceCamera, (value: boolean) => {
@@ -1833,6 +1853,11 @@ watch(selectedCustomDate, (date: Date | null) => {
     userSelectedDates.push(representation);
     events.push(representation);
   }
+  updateAnalemmaLayer({
+    year: selectedCustomDate.value?.getYear() ?? 2026,
+    dayFraction: 0.5,
+    daysBetween: 5,
+  });
 });
 
 watch(inNorthernHemisphere, (_inNorth: boolean) => resetNSEWText());

--- a/src/SeasonsStory.vue
+++ b/src/SeasonsStory.vue
@@ -1481,6 +1481,8 @@ function aspectRatioSetup() {
   updateAzOffsets();
 }
 
+let analemmaLayer: SpreadSheetLayer | null = null;
+
 onMounted(() => {
 
   if (!isWebGL2Enabled()) {
@@ -1523,9 +1525,6 @@ onMounted(() => {
     layersLoaded.value = true;
 
     questionDisplaySetup();
-
-    const layer = await createAnalemmaLayer({ year: 2026, dayFraction: 0.35, daysBetween: 5 });
-    console.log(layer);
 
   });
 
@@ -1692,9 +1691,12 @@ interface AnalemmaLayerOptions {
 
 function createAnalemmaLayer(options: AnalemmaLayerOptions): Promise<SpreadSheetLayer> {
   const start = new Date(options.year, 0);
-  const delta = options.daysBetween * 24 * 60 * 60 * 1000;
+  const delta = options.daysBetween * MILLISECONDS_PER_DAY;
   const end = (new Date(options.year + 1, 0)).getTime();
   let time = start.getTime() + options.dayFraction * MILLISECONDS_PER_DAY;
+  console.log("Start time");
+  console.log(new Date(time));
+  console.log(selectedTimezoneOffset.value);
 
   const points: string[] = [];
   while (time < end) {
@@ -1787,6 +1789,23 @@ watch(currentTime, (_time: Date) => {
     resetView(store.zoomDeg);
   }
   sunDistance.value = sunPlace.get_distance();
+});
+
+watch([selectedLocation, selectedCustomDate], async (values: [LocationDeg, Date | null]) => {
+  if (analemmaLayer) {
+    store.deleteLayer(analemmaLayer);
+  }
+
+  const date = values[1];
+  if (date != null) {
+    analemmaLayer = await createAnalemmaLayer({
+      year: date.getFullYear(),
+      dayFraction: 0.5,
+      daysBetween: 5,
+    });
+  } else {
+    analemmaLayer = null;
+  }
 });
 
 watch(forceCamera, (value: boolean) => {

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -13,6 +13,7 @@ import {
   DT,
   GlyphCache,
   Grids,
+  LayerManager,
   Matrix3d,
   Planets,
   RenderContext,
@@ -225,6 +226,7 @@ export function renderOneFrame(showHorizon=true,
       }
     }
   }
+
   if (this.uiController != null) {
     this.uiController.render(this.renderContext);
   }
@@ -266,6 +268,9 @@ export function renderOneFrame(showHorizon=true,
   if (showHorizon) {
     drawHorizon(this.renderContext, { opacity: 0.9, color: "#01362C" });
   }
+
+  const referenceFrame = this.getCurrentReferenceFrame();
+  LayerManager._draw(this.renderContext, 1, this.get_space(), referenceFrame, true, this.get_space());
 
   const worldSave = this.renderContext.get_world();
   const viewSave = this.renderContext.get_view();


### PR DESCRIPTION
This PR adds functionality for creating a layer representing an analemma. Currently the analemma can be created with a few options:
* Calendar year to use. In general this could be from any yearlong window, but I just made it a calendar year to start to keep things simple
* When during the day to determine the alt/az of the Sun, represented as a fraction of 24 hours.
* How many days between points - decreasing this number will increase the point density of the layer

Right now this layer is connected to the current location - when the location is changed, the underlying alt/az positions will be recauclated.

There is one issue with this - I imagine that the analemma is more useful as something represented relative to the horizon (i.e. in alt/az space), but WWT wants positions in RA/Dec. This means that we need to recalculate the RA/Dec on each frame. When the engine is playing this doesn't look too bad, but it can be slightly jumpy when moving the time slider.

Finally, this doesn't take daylight savings into account at all - the analemma points are all 24 hours apart, without any adjustment when the time zone for a given location changes. Not sure how/if we want to consider that.

CC @patudom 